### PR TITLE
WIP: Do Not Merge! - Recommendations

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.settings.server
 
 import android.util.Log
 import androidx.preference.PreferenceDataStore
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +13,8 @@ import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class ServerSettingsPresenterImpl @Inject constructor(
-    private val serverManager: ServerManager
+    private val serverManager: ServerManager,
+    private val prefsRepository: PrefsRepository
 ) : ServerSettingsPresenter, PreferenceDataStore() {
 
     companion object {
@@ -56,6 +58,10 @@ class ServerSettingsPresenterImpl @Inject constructor(
             "registration_name" -> serverManager.getServer(serverId)?.deviceName
             "connection_internal" -> (serverManager.getServer(serverId)?.connection?.getUrl(isInternal = true, force = true) ?: "").toString()
             "session_timeout" -> serverManager.integrationRepository(serverId).getSessionTimeOut().toString()
+            "header_name_1" -> prefsRepository.getHeaderName1()
+            "header_name_2" -> prefsRepository.getHeaderName2()
+            "header_value_1" -> prefsRepository.getHeaderValue1()
+            "header_value_2" -> prefsRepository.getHeaderValue2()
             else -> throw IllegalArgumentException("No string found by this key: $key")
         }
     }
@@ -100,6 +106,10 @@ class ServerSettingsPresenterImpl @Inject constructor(
                         Log.e(TAG, "Issue saving session timeout value", e)
                     }
                 }
+                "header_name_1" -> prefsRepository.saveHeaderName1(value?.ifBlank { null })
+                "header_name_2" -> prefsRepository.saveHeaderName2(value?.ifBlank { null })
+                "header_value_1" -> prefsRepository.saveHeaderValue1(value?.ifBlank { null })
+                "header_value_2" -> prefsRepository.saveHeaderValue2(value?.ifBlank { null })
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }
         }

--- a/app/src/main/res/xml/preferences_server.xml
+++ b/app/src/main/res/xml/preferences_server.xml
@@ -65,41 +65,17 @@
             app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory
-        android:title="@string/http_header_settings">
-        <Preference
-            android:selectable="false"
-            android:enabled="true"
-            android:key="http_header_settings_summary"
-            android:title=""
-            android:summary="@string/http_header_settings_summary" />
-        <EditTextPreference
-            android:key="header_name_1"
-            android:icon="@drawable/ic_edit"
-            android:title="@string/header_name_1"
-            app:useSimpleSummaryProvider="true"/>
-        <EditTextPreference
-            android:key="header_value_1"
-            android:icon="@drawable/ic_edit"
-            android:title="@string/header_value_1"
-            app:useSimpleSummaryProvider="true"/>
-        <EditTextPreference
-            android:key="header_name_2"
-            android:icon="@drawable/ic_edit"
-            android:title="@string/header_name_2"
-            app:useSimpleSummaryProvider="true"/>
-        <EditTextPreference
-            android:key="header_value_2"
-            android:icon="@drawable/ic_edit"
-            android:title="@string/header_value_2"
-            app:useSimpleSummaryProvider="true"/>
-    </PreferenceCategory>
-    <PreferenceCategory
         android:title="@string/other_settings">
         <Preference
             android:key="websocket"
             android:icon="@drawable/ic_websocket"
             android:title="@string/websocket_setting_name"
             android:summary="@string/websocket_setting_summary" />
+        <Preference
+            android:key="custom_http_headers"
+            android:icon="@drawable/ic_edit"
+            android:title="@string/custom_http_headers_name"
+            android:summary="@string/custom_http_headers_summary" />
         <Preference
             android:key="delete_server"
             android:icon="@drawable/ic_clear"

--- a/app/src/main/res/xml/preferences_server.xml
+++ b/app/src/main/res/xml/preferences_server.xml
@@ -65,6 +65,35 @@
             app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory
+        android:title="@string/http_header_settings">
+        <Preference
+            android:selectable="false"
+            android:enabled="true"
+            android:key="http_header_settings_summary"
+            android:title=""
+            android:summary="@string/http_header_settings_summary" />
+        <EditTextPreference
+            android:key="header_name_1"
+            android:icon="@drawable/ic_edit"
+            android:title="@string/header_name_1"
+            app:useSimpleSummaryProvider="true"/>
+        <EditTextPreference
+            android:key="header_value_1"
+            android:icon="@drawable/ic_edit"
+            android:title="@string/header_value_1"
+            app:useSimpleSummaryProvider="true"/>
+        <EditTextPreference
+            android:key="header_name_2"
+            android:icon="@drawable/ic_edit"
+            android:title="@string/header_name_2"
+            app:useSimpleSummaryProvider="true"/>
+        <EditTextPreference
+            android:key="header_value_2"
+            android:icon="@drawable/ic_edit"
+            android:title="@string/header_value_2"
+            app:useSimpleSummaryProvider="true"/>
+    </PreferenceCategory>
+    <PreferenceCategory
         android:title="@string/other_settings">
         <Preference
             android:key="websocket"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.0.0")
+        classpath("com.android.tools.build:gradle:8.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
         classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-appdistribution-gradle:4.0.0")

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -39,6 +39,22 @@ interface PrefsRepository {
 
     suspend fun saveScreenOrientation(orientation: String?)
 
+    suspend fun getHeaderName1(): String?
+
+    suspend fun saveHeaderName1(headerName1: String?)
+
+    suspend fun getHeaderName2(): String?
+
+    suspend fun saveHeaderName2(headerName2: String?)
+
+    suspend fun getHeaderValue1(): String?
+
+    suspend fun saveHeaderValue1(headerValue1: String?)
+
+    suspend fun getHeaderValue2(): String?
+
+    suspend fun saveHeaderValue2(headerValue2: String?)
+
     suspend fun isPinchToZoomEnabled(): Boolean
 
     suspend fun setPinchToZoomEnabled(enabled: Boolean)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -20,6 +20,10 @@ class PrefsRepositoryImpl @Inject constructor(
         private const val PREF_LANG = "lang"
         private const val PREF_LOCALES = "locales"
         private const val PREF_SCREEN_ORIENTATION = "screen_orientation"
+        private const val PREF_HEADER_NAME_1 = "header_name_1"
+        private const val PREF_HEADER_NAME_2 = "header_name_2"
+        private const val PREF_HEADER_VALUE_1 = "header_value_1"
+        private const val PREF_HEADER_VALUE_2 = "header_value_2"
         private const val PREF_CONTROLS_AUTH_REQUIRED = "controls_auth_required"
         private const val PREF_CONTROLS_AUTH_ENTITIES = "controls_auth_entities"
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
@@ -104,6 +108,38 @@ class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun saveScreenOrientation(orientation: String?) {
         localStorage.putString(PREF_SCREEN_ORIENTATION, orientation)
+    }
+
+    override suspend fun getHeaderName1(): String? {
+        return localStorage.getString(PREF_HEADER_NAME_1)
+    }
+
+    override suspend fun getHeaderName2(): String? {
+        return localStorage.getString(PREF_HEADER_NAME_2)
+    }
+
+    override suspend fun getHeaderValue1(): String? {
+        return localStorage.getString(PREF_HEADER_VALUE_1)
+    }
+
+    override suspend fun getHeaderValue2(): String? {
+        return localStorage.getString(PREF_HEADER_VALUE_2)
+    }
+
+    override suspend fun saveHeaderName1(headerName1: String?) {
+        localStorage.putString(PREF_HEADER_NAME_1, headerName1)
+    }
+
+    override suspend fun saveHeaderName2(headerName2: String?) {
+        localStorage.putString(PREF_HEADER_NAME_2, headerName2)
+    }
+
+    override suspend fun saveHeaderValue1(headerValue1: String?) {
+        localStorage.putString(PREF_HEADER_VALUE_1, headerValue1)
+    }
+
+    override suspend fun saveHeaderValue2(headerValue2: String?) {
+        localStorage.putString(PREF_HEADER_VALUE_2, headerValue2)
     }
 
     override suspend fun getControlsAuthRequired(): ControlsAuthRequiredSetting {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -152,6 +152,10 @@
     <string name="crash_reporting_summary">Help the developers fix bugs and crashes by leaving this enabled. If the application crashes this will automatically generate and send a report. If you notice a crash also create an issue on Github!</string>
     <string name="crash_reporting">Crash Reporting</string>
     <string name="create_template">Create Template</string>
+    <string name="custom_header_name">Header name</string>
+    <string name="custom_header_value">Header value</string>
+    <string name="custom_http_headers_name">Custom Http Headers</string>
+    <string name="custom_http_headers_summary">Manage custom headers included in every request sent to your Home Assistant server.</string>
     <string name="database_event_failure">Unable to send migration failure event to Home Assistant</string>
     <string name="database_migration_failed">Database migration failed, all sensor and widget data has been reset. Please re-enable your sensors and recreate your widgets.</string>
     <string name="delete">Delete</string>
@@ -256,10 +260,6 @@
     <string name="screen_orientation_option_value_landscape">landscape</string>
     <string name="get_help">Get Help</string>
     <string name="grant_permission">Grant Permission</string>
-    <string name="header_name_1">Name of the 1. header</string>
-    <string name="header_name_2">Name of the 2. header</string>
-    <string name="header_value_1">Value of the 1. header</string>
-    <string name="header_value_2">Value of the 2. header</string>
     <string name="help">Help</string>
     <string name="hide">Hide</string>
     <string name="high_accuracy_mode_channel_name">High accuracy location</string>
@@ -267,8 +267,6 @@
     <string name="history">History</string>
     <string name="hold_to_reorder">Tap and hold to reorder</string>
     <string name="home_assistant_not_discover">Unable to find your\nHome Assistant instance</string>
-    <string name="http_header_settings">Additional Http Headers</string>
-    <string name="http_header_settings_summary">Enter Http header items with names and values. These header items will be added to all API calls to the Home Assistant server. These header items can be used (for example) to bypass Cloudflare SSO.</string>
     <string name="icon">Icon</string>
     <string name="input_booleans">Input Booleans</string>
     <string name="input_buttons">Input Buttons</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -256,6 +256,10 @@
     <string name="screen_orientation_option_value_landscape">landscape</string>
     <string name="get_help">Get Help</string>
     <string name="grant_permission">Grant Permission</string>
+    <string name="header_name_1">Name of the 1. header</string>
+    <string name="header_name_2">Name of the 2. header</string>
+    <string name="header_value_1">Value of the 1. header</string>
+    <string name="header_value_2">Value of the 2. header</string>
     <string name="help">Help</string>
     <string name="hide">Hide</string>
     <string name="high_accuracy_mode_channel_name">High accuracy location</string>
@@ -263,6 +267,8 @@
     <string name="history">History</string>
     <string name="hold_to_reorder">Tap and hold to reorder</string>
     <string name="home_assistant_not_discover">Unable to find your\nHome Assistant instance</string>
+    <string name="http_header_settings">Additional Http Headers</string>
+    <string name="http_header_settings_summary">Enter Http header items with names and values. These header items will be added to all API calls to the Home Assistant server. These header items can be used (for example) to bypass Cloudflare SSO.</string>
     <string name="icon">Icon</string>
     <string name="input_booleans">Input Booleans</string>
     <string name="input_buttons">Input Buttons</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,4 @@ android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
+org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
This is just some recommendations, use that if you think it's a good idea, if not, do not care about this 😉

Goals:
- Create a `Custom HTTP headers` setting page.
- Allowing users to add N custom headers.
- Using same logic as [`Servers devices`](https://github.com/Meister1977/home-assistant-android/blob/e40575fcd87b0fab2a8caa4fd45260188d72b501/app/src/main/res/xml/preferences.xml#L5C1-L8)


I'm not sure, but it seems that the current implementation of storage (using localStorage) will share this settings across all HA Servers within the app, which might not be ideal.
It would be better to implement the same storage used by other server-related parameters such as the name, device name, and the URL. If I'm not misleading this logic is present here [ServerSettingsFragment.kt](https://github.com/Meister1977/home-assistant-android/blob/master/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt)